### PR TITLE
Make action name consistent

### DIFF
--- a/actionhandlers/textlabel.go
+++ b/actionhandlers/textlabel.go
@@ -5,7 +5,7 @@ import (
 	"github.com/magicmonkey/go-streamdeck/buttons"
 )
 
-type TextLabelChange struct {
+type TextLabelChangeAction struct {
 	NewLabel string
 }
 


### PR DESCRIPTION
Every other action is called *Action so perhaps this one should match.