### PR TITLE
Add the devices loading to the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ import (
 	streamdeck "github.com/magicmonkey/go-streamdeck"
 	"github.com/magicmonkey/go-streamdeck/actionhandlers"
 	"github.com/magicmonkey/go-streamdeck/buttons"
+	_ "github.com/magicmonkey/go-streamdeck/devices"
 )
 
 func main() {


### PR DESCRIPTION
The import devices line wasn't included in the README high level usage example so this adds it.