### PR TITLE
Add support for streamdeck mini

### DIFF
--- a/buttons/imagefile.go
+++ b/buttons/imagefile.go
@@ -21,7 +21,7 @@ type ImageFileButton struct {
 // GetImageForButton is the interface implemention to get the button's image as an image.Image
 func (btn *ImageFileButton) GetImageForButton() image.Image {
 	// TODO base the 96 on the image bounds
-	newimg := image.NewRGBA(image.Rect(0, 0, 96, 96))
+	newimg := image.NewRGBA(image.Rect(0, 0, 80, 80))
 	draw.Draw(newimg, newimg.Bounds(), btn.img, image.Point{0, 0}, draw.Src)
 	return newimg
 }
@@ -59,7 +59,7 @@ func (btn *ImageFileButton) loadImage() error {
 	newimg, ok := img.(*image.RGBA)
 	if !ok {
 		// TODO base the 96 on the button size
-		newimg = image.NewRGBA(image.Rect(0, 0, 96, 96))
+		newimg = image.NewRGBA(image.Rect(0, 0, 80, 80))
 		draw.Draw(newimg, newimg.Bounds(), img, image.Point{0, 0}, draw.Src)
 	}
 

--- a/devices/mini.go
+++ b/devices/mini.go
@@ -1,0 +1,61 @@
+package devices
+
+import (
+	"image"
+
+	streamdeck "github.com/magicmonkey/go-streamdeck"
+)
+
+var (
+	miniName                     string
+	miniButtonWidth              uint
+	miniButtonHeight             uint
+	miniImageReportPayloadLength uint
+	miniImageReportHeaderLength  uint
+	miniImageReportLength        uint
+)
+
+// GetImageHeaderMini returns the USB comms header for a button image for the XL
+func GetImageHeaderMini(bytesRemaining uint, btnIndex uint, pageNumber uint) []byte {
+	thisLength := uint(0)
+	if miniImageReportPayloadLength < bytesRemaining {
+		thisLength = miniImageReportPayloadLength
+	} else {
+		thisLength = bytesRemaining
+	}
+	header := []byte{'\x02', '\x07', byte(btnIndex)}
+	if thisLength == bytesRemaining {
+		header = append(header, '\x01')
+	} else {
+		header = append(header, '\x00')
+	}
+
+	header = append(header, byte(thisLength&0xff))
+	header = append(header, byte(thisLength>>8))
+
+	header = append(header, byte(pageNumber&0xff))
+	header = append(header, byte(pageNumber>>8))
+
+	return header
+}
+
+func init() {
+	miniName = "Streamdeck Mini"
+	miniButtonWidth = 80
+	miniButtonHeight = 80
+	miniImageReportLength = 1024
+	miniImageReportHeaderLength = 16
+	miniImageReportPayloadLength = miniImageReportLength - miniImageReportHeaderLength
+	streamdeck.RegisterDevicetype(
+		miniName, // Name
+		image.Point{X: int(miniButtonWidth), Y: int(miniButtonHeight)}, // Width/height of a button
+		0x63,                        // USB productID
+		[]byte{'\x03', '\x02'},      // Reset packet
+		6,                          // Number of buttons
+		[]byte{'\x03', '\x08'},      // Set brightness packet preamble
+		4,                           // Button read offset
+		"JPEG",                      // Image format
+		miniImageReportPayloadLength, // Amount of image payload allowed per USB packet
+		GetImageHeaderMini,           // Function to get the comms image header
+	)
+}

--- a/image.go
+++ b/image.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/disintegration/gift"
+	"golang.org/x/image/bmp"
 )
 
 func resizeAndRotate(img image.Image, width, height int) image.Image {
@@ -30,6 +31,8 @@ func getImageForButton(img image.Image, btnFormat string) ([]byte, error) {
 	switch btnFormat {
 	case "JPEG":
 		jpeg.Encode(&b, img, nil)
+	case "BMP":
+		bmp.Encode(&b, img)
 	default:
 		return nil, errors.New("Unknown button image format: " + btnFormat)
 	}
@@ -37,7 +40,7 @@ func getImageForButton(img image.Image, btnFormat string) ([]byte, error) {
 }
 
 func getSolidColourImage(colour color.Color) *image.RGBA {
-	ButtonSize := 96
+	ButtonSize := 80
 	img := image.NewRGBA(image.Rect(0, 0, ButtonSize, ButtonSize))
 	//colour := color.RGBA{red, green, blue, 0}
 	draw.Draw(img, img.Bounds(), image.NewUniform(colour), image.Point{0, 0}, draw.Src)


### PR DESCRIPTION
Adds preliminary Device definition for the StreamDeck Mini. 

This PR is for Discussion rather than any actual merge as several hardcoded values need to be updated before this could logistically be merged into master.

