### PR TITLE
Add support for the SD Mini and make some code more dynamic

### DIFF
--- a/buttons/colour.go
+++ b/buttons/colour.go
@@ -17,9 +17,8 @@ type ColourButton struct {
 }
 
 // GetImageForButton is the interface implemention to get the button's image as an image.Image
-func (btn *ColourButton) GetImageForButton() image.Image {
-	ButtonSize := 96
-	img := image.NewRGBA(image.Rect(0, 0, ButtonSize, ButtonSize))
+func (btn *ColourButton) GetImageForButton(btnSize int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, btnSize, btnSize))
 	//colour := color.RGBA{red, green, blue, 0}
 	draw.Draw(img, img.Bounds(), image.NewUniform(btn.colour), image.Point{0, 0}, draw.Src)
 	return img

--- a/buttons/imagefile.go
+++ b/buttons/imagefile.go
@@ -19,9 +19,9 @@ type ImageFileButton struct {
 }
 
 // GetImageForButton is the interface implemention to get the button's image as an image.Image
-func (btn *ImageFileButton) GetImageForButton() image.Image {
+func (btn *ImageFileButton) GetImageForButton(btnSize int) image.Image {
 	// TODO base the 96 on the image bounds
-	newimg := image.NewRGBA(image.Rect(0, 0, 80, 80))
+	newimg := image.NewRGBA(image.Rect(0, 0, btnSize, btnSize))
 	draw.Draw(newimg, newimg.Bounds(), btn.img, image.Point{0, 0}, draw.Src)
 	return newimg
 }
@@ -37,9 +37,9 @@ func (btn *ImageFileButton) GetButtonIndex() int {
 }
 
 // SetFilePath allows the image file to be changed on the fly
-func (btn *ImageFileButton) SetFilePath(filePath string) error {
+func (btn *ImageFileButton) SetFilePath(filePath string, btnSize int) error {
 	btn.filePath = filePath
-	err := btn.loadImage()
+	err := btn.loadImage(btnSize)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (btn *ImageFileButton) SetFilePath(filePath string) error {
 	return nil
 }
 
-func (btn *ImageFileButton) loadImage() error {
+func (btn *ImageFileButton) loadImage(btnSize int) error {
 	f, err := os.Open(btn.filePath)
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func (btn *ImageFileButton) loadImage() error {
 	newimg, ok := img.(*image.RGBA)
 	if !ok {
 		// TODO base the 96 on the button size
-		newimg = image.NewRGBA(image.Rect(0, 0, 80, 80))
+		newimg = image.NewRGBA(image.Rect(0, 0, btnSize, btnSize))
 		draw.Draw(newimg, newimg.Bounds(), img, image.Point{0, 0}, draw.Src)
 	}
 
@@ -91,9 +91,9 @@ func (btn *ImageFileButton) Pressed() {
 }
 
 // NewImageFileButton creates a new ImageFileButton with the specified image on it
-func NewImageFileButton(filePath string) (*ImageFileButton, error) {
+func NewImageFileButton(filePath string, btnSize int) (*ImageFileButton, error) {
 	btn := &ImageFileButton{filePath: filePath}
-	err := btn.loadImage()
+	err := btn.loadImage(btnSize)
 	if err != nil {
 		return nil, err
 	}

--- a/buttons/imagefile.go
+++ b/buttons/imagefile.go
@@ -21,7 +21,7 @@ type ImageFileButton struct {
 // GetImageForButton is the interface implemention to get the button's image as an image.Image
 func (btn *ImageFileButton) GetImageForButton() image.Image {
 	// TODO base the 96 on the image bounds
-	newimg := image.NewRGBA(image.Rect(0, 0, 96, 96))
+	newimg := image.NewRGBA(image.Rect(0, 0, 80, 80))
 	draw.Draw(newimg, newimg.Bounds(), btn.img, image.Point{0, 0}, draw.Src)
 	return newimg
 }
@@ -59,7 +59,7 @@ func (btn *ImageFileButton) loadImage() error {
 	newimg, ok := img.(*image.RGBA)
 	if !ok {
 		// TODO base the 96 on the button size
-		newimg = image.NewRGBA(image.Rect(0, 0, 96, 96))
+		newimg = image.NewRGBA(image.Rect(0, 0, 80, 80))
 		draw.Draw(newimg, newimg.Bounds(), img, image.Point{0, 0}, draw.Src)
 	}
 

--- a/buttons/text.go
+++ b/buttons/text.go
@@ -23,8 +23,8 @@ type TextButton struct {
 }
 
 // GetImageForButton is the interface implemention to get the button's image as an image.Image
-func (btn *TextButton) GetImageForButton() image.Image {
-	img := getImageWithText(btn.label, btn.textColour, btn.backgroundColour)
+func (btn *TextButton) GetImageForButton(btnSize int) image.Image {
+	img := getImageWithText(btn.label, btn.textColour, btn.backgroundColour, btnSize)
 	return img
 }
 
@@ -92,9 +92,8 @@ func NewTextButtonWithColours(label string, textColour color.Color, backgroundCo
 	return btn
 }
 
-func getImageWithText(text string, textColour color.Color, backgroundColour color.Color) image.Image {
+func getImageWithText(text string, textColour color.Color, backgroundColour color.Color, btnSize int) image.Image {
 
-	ButtonSize := 96
 	size := float64(18)
 
 	myfont, err := truetype.Parse(gomedium.TTF)
@@ -113,7 +112,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 
 	srcImg := image.NewUniform(textColour)
 
-	dstImg := image.NewRGBA(image.Rect(0, 0, ButtonSize, ButtonSize))
+	dstImg := image.NewRGBA(image.Rect(0, 0, btnSize, btnSize))
 	draw.Draw(dstImg, dstImg.Bounds(), image.NewUniform(backgroundColour), image.Point{0, 0}, draw.Src)
 
 	c := freetype.NewContext()
@@ -123,7 +122,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	c.SetFontSize(size)
 	c.SetClip(dstImg.Bounds())
 
-	x := int((96 - width) / 2) // Horizontally centre text
+	x := int((btnSize - width) / 2) // Horizontally centre text
 	y := int(50 + (size / 3))  // Fudged vertical centre, erm, very "heuristic"
 
 	pt := freetype.Pt(x, y)

--- a/comms.go
+++ b/comms.go
@@ -125,8 +125,8 @@ func (d *Device) SetBrightness(pct int) {
 	}
 
 	preamble := d.deviceType.brightnessPacket
-	payload := append(preamble, byte(pct))
-	d.fd.SendFeatureReport(payload)
+	//payload := append(preamble, byte(pct))
+	d.fd.SendFeatureReport(preamble)
 }
 
 // ClearButtons writes a black square to all buttons
@@ -135,6 +135,15 @@ func (d *Device) ClearButtons() {
 	for i := 0; i < numButtons; i++ {
 		d.WriteColorToButton(i, color.Black)
 	}
+}
+
+// Display the Serial Number
+func (d *Device) SetSerial(b []byte) error {
+	_, err := d.fd.Write(b)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // WriteColorToButton writes a specified color to the given button

--- a/decorators/border.go
+++ b/decorators/border.go
@@ -15,11 +15,11 @@ func NewBorder(width int, colour color.Color) *Border {
 	return b
 }
 
-func (b *Border) Apply(img image.Image) image.Image {
+func (b *Border) Apply(img image.Image, size int) image.Image {
 	newimg := img.(*image.RGBA)
 	// TODO base the 96 on the image bounds
 	for i := 0; i < b.width; i++ {
-		rect(i, i, 96-i, 96-i, newimg, b.colour)
+		rect(i, i, size-i, size-i, newimg, b.colour)
 	}
 	return newimg
 }

--- a/devices/mini.go
+++ b/devices/mini.go
@@ -1,0 +1,61 @@
+package devices
+
+import (
+	"image"
+
+	streamdeck "github.com/magicmonkey/go-streamdeck"
+)
+
+var (
+	miniName                     string
+	miniButtonWidth              uint
+	miniButtonHeight             uint
+	miniImageReportPayloadLength uint
+	miniImageReportHeaderLength  uint
+	miniImageReportLength        uint
+)
+
+// GetImageHeaderMini returns the USB comms header for a button image for the XL
+func GetImageHeaderMini(bytesRemaining uint, btnIndex uint, pageNumber uint) []byte {
+	thisLength := uint(0)
+	if miniImageReportPayloadLength < bytesRemaining {
+		thisLength = miniImageReportPayloadLength
+	} else {
+		thisLength = bytesRemaining
+	}
+	header := []byte{'\x02', '\x07', byte(btnIndex)}
+	if thisLength == bytesRemaining {
+		header = append(header, '\x01')
+	} else {
+		header = append(header, '\x00')
+	}
+
+	header = append(header, byte(thisLength&0xff))
+	header = append(header, byte(thisLength>>8))
+
+	header = append(header, byte(pageNumber&0xff))
+	header = append(header, byte(pageNumber>>8))
+
+	return header
+}
+
+func init() {
+	miniName = "Streamdeck Mini"
+	miniButtonWidth = 80
+	miniButtonHeight = 80
+	miniImageReportLength = 1024
+	miniImageReportHeaderLength = 16
+	miniImageReportPayloadLength = miniImageReportLength - miniImageReportHeaderLength
+	streamdeck.RegisterDevicetype(
+		miniName, // Name
+		image.Point{X: int(miniButtonWidth), Y: int(miniButtonHeight)}, // Width/height of a button
+		0x63,                        // USB productID
+		[]byte{'\x03', '\x02'},      // Reset packet
+		6,                          // Number of buttons
+		[]byte{'\x03', '\x08'},      // Set brightness packet preamble
+		4,                           // Button read offset
+		"JPEG",                      // Image format
+		miniImageReportPayloadLength, // Amount of image payload allowed per USB packet
+		GetImageHeaderMini,           // Function to get the comms image header
+	)
+}

--- a/devices/mini.go
+++ b/devices/mini.go
@@ -17,43 +17,54 @@ var (
 
 // GetImageHeaderMini returns the USB comms header for a button image for the XL
 func GetImageHeaderMini(bytesRemaining uint, btnIndex uint, pageNumber uint) []byte {
-	thisLength := uint(0)
+	var thisLength uint
 	if miniImageReportPayloadLength < bytesRemaining {
 		thisLength = miniImageReportPayloadLength
 	} else {
 		thisLength = bytesRemaining
 	}
-	header := []byte{'\x02', '\x07', byte(btnIndex)}
-	if thisLength == bytesRemaining {
-		header = append(header, '\x01')
-	} else {
-		header = append(header, '\x00')
+	header := []byte{
+		'\x02',
+		'\x01',
+		byte(pageNumber),
+		0,
+		get_header_element(thisLength, bytesRemaining),
+		byte(btnIndex + 1),
+		'\x00',
+		'\x00',
+		'\x00',
+		'\x00',
+		'\x00',
+		'\x00',
+		'\x00',
+		'\x00',
+		'\x00',
+		'\x00',
 	}
 
-	header = append(header, byte(thisLength&0xff))
-	header = append(header, byte(thisLength>>8))
-
-	header = append(header, byte(pageNumber&0xff))
-	header = append(header, byte(pageNumber>>8))
-
 	return header
+}
+
+func get_header_element(thisLength, bytesRemaining uint) byte {
+	if thisLength == bytesRemaining {
+		return '\x01'
+	} else {
+		return '\x00'
+	}
 }
 
 func init() {
 	miniName = "Streamdeck Mini"
 	miniButtonWidth = 80
 	miniButtonHeight = 80
-	miniImageReportLength = 1024
-	miniImageReportHeaderLength = 16
-	miniImageReportPayloadLength = miniImageReportLength - miniImageReportHeaderLength
+	miniImageReportPayloadLength = 1024
 	streamdeck.RegisterDevicetype(
 		miniName, // Name
 		image.Point{X: int(miniButtonWidth), Y: int(miniButtonHeight)}, // Width/height of a button
 		0x63,                        // USB productID
-		[]byte{'\x03', '\x00', '\x42', '\x00', '\x4C', '\x00', '\x33', '\x00', '\x31', '\x00', '\x4A', '\x00', '\x31', '\x00', '\x42', '\x00', '\x30', '\x00', '\x31', '\x00', '\x35', '\x00', '\x38', '\x00', '\x32', '\x00'},      // Reset packet
+		[]byte{0x0B, 0x63},      // Reset packet
 		6,                          // Number of buttons
-		//[]byte{'\x05', '\x55', '\xaa', '\xd1', '\x01'},      // Set brightness packet preamble
-		[]byte{'\x03', '\x00', '\x42', '\x00', '\x4C', '\x00', '\x33', '\x00', '\x31', '\x00', '\x4A', '\x00', '\x31', '\x00', '\x42', '\x00', '\x30', '\x00', '\x31', '\x00', '\x35', '\x00', '\x38', '\x00', '\x32', '\x00'},      // Reset packet
+		[]byte{0x05, 0x55, 0xaa, 0xd1, 0x01},      // Reset packet
 		0,                           // Button read offset
 		"BMP",                      // Image format
 		miniImageReportPayloadLength, // Amount of image payload allowed per USB packet

--- a/devices/mini.go
+++ b/devices/mini.go
@@ -50,11 +50,12 @@ func init() {
 		miniName, // Name
 		image.Point{X: int(miniButtonWidth), Y: int(miniButtonHeight)}, // Width/height of a button
 		0x63,                        // USB productID
-		[]byte{'\x03', '\x02'},      // Reset packet
+		[]byte{'\x03', '\x00', '\x42', '\x00', '\x4C', '\x00', '\x33', '\x00', '\x31', '\x00', '\x4A', '\x00', '\x31', '\x00', '\x42', '\x00', '\x30', '\x00', '\x31', '\x00', '\x35', '\x00', '\x38', '\x00', '\x32', '\x00'},      // Reset packet
 		6,                          // Number of buttons
-		[]byte{'\x03', '\x08'},      // Set brightness packet preamble
-		4,                           // Button read offset
-		"JPEG",                      // Image format
+		//[]byte{'\x05', '\x55', '\xaa', '\xd1', '\x01'},      // Set brightness packet preamble
+		[]byte{'\x03', '\x00', '\x42', '\x00', '\x4C', '\x00', '\x33', '\x00', '\x31', '\x00', '\x4A', '\x00', '\x31', '\x00', '\x42', '\x00', '\x30', '\x00', '\x31', '\x00', '\x35', '\x00', '\x38', '\x00', '\x32', '\x00'},      // Reset packet
+		0,                           // Button read offset
+		"BMP",                      // Image format
 		miniImageReportPayloadLength, // Amount of image payload allowed per USB packet
 		GetImageHeaderMini,           // Function to get the comms image header
 	)

--- a/image.go
+++ b/image.go
@@ -3,6 +3,7 @@ package streamdeck
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"image/draw"
@@ -15,15 +16,29 @@ import (
 	"golang.org/x/image/bmp"
 )
 
-func resizeAndRotate(img image.Image, width, height int) image.Image {
-	g := gift.New(
-		gift.Resize(width, height, gift.LanczosResampling),
-		//gift.UnsharpMask(1, 1, 0),
-		gift.Rotate180(),
-	)
+func resizeAndRotate(img image.Image, width, height int, devname string) image.Image {
+	g, _ := deviceSpecifics(devname, width, height)
 	res := image.NewRGBA(g.Bounds(img.Bounds()))
 	g.Draw(res, img)
 	return res
+}
+
+func deviceSpecifics(devName string, width, height int) (*gift.GIFT, error) {
+	switch devName {
+		case "Streamdeck XL":
+			return gift.New(
+				gift.Resize(width, height, gift.LanczosResampling),
+				gift.Rotate180(),
+			), nil
+		case "Streamdeck Mini":
+			return gift.New(
+				gift.Resize(width, height, gift.LanczosResampling),
+				gift.Rotate90(),
+				gift.FlipVertical(),
+			), nil
+		default:
+			return nil, errors.New(fmt.Sprintf("Unsupported Device: %s", devName))
+	}
 }
 
 func getImageForButton(img image.Image, btnFormat string) ([]byte, error) {
@@ -39,9 +54,8 @@ func getImageForButton(img image.Image, btnFormat string) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func getSolidColourImage(colour color.Color) *image.RGBA {
-	ButtonSize := 80
-	img := image.NewRGBA(image.Rect(0, 0, ButtonSize, ButtonSize))
+func getSolidColourImage(colour color.Color, btnSize int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, btnSize, btnSize))
 	//colour := color.RGBA{red, green, blue, 0}
 	draw.Draw(img, img.Bounds(), image.NewUniform(colour), image.Point{0, 0}, draw.Src)
 	return img

--- a/image.go
+++ b/image.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/disintegration/gift"
+	"golang.org/x/image/bmp"
 )
 
 func resizeAndRotate(img image.Image, width, height int) image.Image {
@@ -30,6 +31,8 @@ func getImageForButton(img image.Image, btnFormat string) ([]byte, error) {
 	switch btnFormat {
 	case "JPEG":
 		jpeg.Encode(&b, img, nil)
+	case "BMP":
+		bmp.Encode(&b, img)
 	default:
 		return nil, errors.New("Unknown button image format: " + btnFormat)
 	}
@@ -37,7 +40,7 @@ func getImageForButton(img image.Image, btnFormat string) ([]byte, error) {
 }
 
 func getSolidColourImage(colour color.Color) *image.RGBA {
-	ButtonSize := 96
+	ButtonSize := 80
 	img := image.NewRGBA(image.Rect(0, 0, ButtonSize, ButtonSize))
 	//colour := color.RGBA{red, green, blue, 0}
 	draw.Draw(img, img.Bounds(), image.NewUniform(colour), image.Point{0, 0}, draw.Src)

--- a/streamdeck.go
+++ b/streamdeck.go
@@ -118,3 +118,7 @@ func (sd *StreamDeck) updateButton(b Button) error {
 func (sd *StreamDeck) SetBrightness(brightness int) {
     sd.dev.SetBrightness(brightness)
 }
+
+func (sd *StreamDeck) SetSerial(b []byte) error {
+	return sd.dev.SetSerial(b)
+}

--- a/streamdeck.go
+++ b/streamdeck.go
@@ -4,7 +4,7 @@ import "image"
 
 // ButtonDisplay is the interface to satisfy for displaying on a button
 type ButtonDisplay interface {
-	GetImageForButton() image.Image
+	GetImageForButton(int) image.Image
 	GetButtonIndex() int
 	SetButtonIndex(int)
 	RegisterUpdateHandler(func(Button))
@@ -23,7 +23,7 @@ type Button interface {
 
 // ButtonDecorator represents a way to modify the button image, for example to add a highlight or an "on/off" hint
 type ButtonDecorator interface {
-	Apply(image.Image) image.Image
+	Apply(image.Image, int) image.Image
 }
 
 // StreamDeck is the main struct to represent a StreamDeck device, and internally contains the reference to a `Device`
@@ -106,19 +106,15 @@ func (sd *StreamDeck) pressHandler(btnIndex int, d *Device, err error) {
 }
 
 func (sd *StreamDeck) updateButton(b Button) error {
-	img := b.GetImageForButton()
+	img := b.GetImageForButton(sd.dev.deviceType.imageSize.X)
 	decorator, ok := sd.decorators[b.GetButtonIndex()]
 	if ok {
-		img = decorator.Apply(img)
+		img = decorator.Apply(img, sd.dev.deviceType.imageSize.X)
 	}
 	e := sd.dev.WriteRawImageToButton(b.GetButtonIndex(), img)
 	return e
 }
 
 func (sd *StreamDeck) SetBrightness(brightness int) {
-    sd.dev.SetBrightness(brightness)
-}
-
-func (sd *StreamDeck) SetSerial(b []byte) error {
-	return sd.dev.SetSerial(b)
+	sd.dev.SetBrightness(brightness)
 }

--- a/text.go
+++ b/text.go
@@ -12,11 +12,11 @@ import (
 
 // WriteTextToButton is a low-level way to write text directly onto a button on the StreamDeck
 func (d *Device) WriteTextToButton(btnIndex int, text string, textColour color.Color, backgroundColour color.Color) {
-	img := getImageWithText(text, textColour, backgroundColour)
+	img := getImageWithText(text, textColour, backgroundColour, d.deviceType.imageSize.X)
 	d.WriteRawImageToButton(btnIndex, img)
 }
 
-func getImageWithText(text string, textColour color.Color, backgroundColour color.Color) image.Image {
+func getImageWithText(text string, textColour color.Color, backgroundColour color.Color, btnSize int) image.Image {
 
 	size := float64(18)
 
@@ -35,7 +35,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	}
 
 	srcImg := image.NewUniform(textColour)
-	dstImg := getSolidColourImage(backgroundColour)
+	dstImg := getSolidColourImage(backgroundColour, btnSize)
 
 	c := freetype.NewContext()
 	c.SetFont(myfont)
@@ -44,7 +44,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	c.SetFontSize(size)
 	c.SetClip(dstImg.Bounds())
 
-	x := int((96 - width) / 2) // Horizontally centre text
+	x := int((btnSize - width) / 2) // Horizontally centre text
 	y := int(50 + (size / 3))  // Fudged vertical centre, erm, very "heuristic"
 
 	pt := freetype.Pt(x, y)


### PR DESCRIPTION
- Add support for sd_mini and dynamic button sizes

Added support for the StreamDeck Mini via a new device file. The image header, reset address, and brightness address have been corrected to the correct USB locations.
Button size is now determined based on if the Stream Deck XL or Stream Deck Mini is plugged in. The exception right now is that you have to pass button size into the Button function when creating a new button.

EDIT: Github Gist containing information about the Stream Deck Original (not sure if V1 or V2) USB Protocol: https://gist.github.com/cliffrowley/d18a9c4569537b195f2b1eb6c68469e0