### PR TITLE
Improve Device definitions

### DIFF
--- a/comms.go
+++ b/comms.go
@@ -18,6 +18,8 @@ type deviceType struct {
 	usbProductID        uint16
 	resetPacket         []byte
 	numberOfButtons     uint
+	buttonRows          uint
+	buttonCols          uint
 	brightnessPacket    []byte
 	buttonReadOffset    uint
 	imageFormat         string
@@ -34,6 +36,8 @@ func RegisterDevicetype(
 	usbProductID uint16,
 	resetPacket []byte,
 	numberOfButtons uint,
+	buttonRows uint,
+	buttonCols uint,
 	brightnessPacket []byte,
 	buttonReadOffset uint,
 	imageFormat string,
@@ -46,6 +50,8 @@ func RegisterDevicetype(
 		usbProductID:        usbProductID,
 		resetPacket:         resetPacket,
 		numberOfButtons:     numberOfButtons,
+		buttonRows:          buttonRows,
+		buttonCols:          buttonCols,
 		brightnessPacket:    brightnessPacket,
 		buttonReadOffset:    buttonReadOffset,
 		imageFormat:         imageFormat,

--- a/devices/mini.go
+++ b/devices/mini.go
@@ -58,14 +58,26 @@ func init() {
 	miniButtonWidth = 80
 	miniButtonHeight = 80
 	miniImageReportPayloadLength = 1024
+	// Get reset packet from device name
+	reset, err := resetPacket(miniName)
+	if err != nil {
+		panic(err)
+	}
+	// Get brightness packet from device name
+	brightness, err := brightnessPacket(miniName)
+	if err != nil {
+		panic(err)
+	}
 	streamdeck.RegisterDevicetype(
 		miniName, // Name
 		image.Point{X: int(miniButtonWidth), Y: int(miniButtonHeight)}, // Width/height of a button
 		0x63,                        // USB productID
-		[]byte{0x0B, 0x63},      // Reset packet
+		reset,                      // Reset packet
 		6,                          // Number of buttons
-		[]byte{0x05, 0x55, 0xaa, 0xd1, 0x01},      // Reset packet
-		0,                           // Button read offset
+		2,                           // Number of rows
+		3,                           // Number of cols
+		brightness,                  // Reset packet
+		1,                           // Button read offset
 		"BMP",                      // Image format
 		miniImageReportPayloadLength, // Amount of image payload allowed per USB packet
 		GetImageHeaderMini,           // Function to get the comms image header

--- a/devices/origv2.go
+++ b/devices/origv2.go
@@ -42,13 +42,25 @@ func init() {
 	ov2ButtonWidth = 72
 	ov2ButtonHeight = 72
 	ov2ImageReportPayloadLength = 1024
+	// Get reset packet based on device
+	reset, err := resetPacket(ov2Name)
+	if err != nil {
+		panic(err)
+	}
+	// Get brightness packet based on device
+	brightness, err := brightnessPacket(ov2Name)
+	if err != nil {
+		panic(err)
+	}
 	streamdeck.RegisterDevicetype(
 		ov2Name, // Name
 		image.Point{X: int(ov2ButtonWidth), Y: int(ov2ButtonHeight)}, // Width/height of a button
 		0x6d,                        // USB productID
-		[]byte{'\x03', '\x02'},      // Reset packet
+		reset,                       // Reset packet
 		15,                          // Number of buttons
-		[]byte{'\x03', '\x08'},      // Set brightness packet preamble
+		3,                           // Number of rows
+		5,                           // Number of columns
+		brightness,                  // Set brightness packet preamble
 		4,                           // Button read offset
 		"JPEG",                      // Image format
 		ov2ImageReportPayloadLength, // Amount of image payload allowed per USB packet

--- a/devices/shared.go
+++ b/devices/shared.go
@@ -1,0 +1,51 @@
+package devices
+
+import "errors"
+
+func resetPacket(device string) ([]byte, error) {
+	var size int
+	var header []byte
+	
+	switch device {
+	case "Streamdeck XL", "Streamdeck (original v2)":
+		size = 32
+		header = []byte{0x03, 0x02}
+	case "Streamdeck Mini":
+		size = 17
+		header = []byte{0x0b, 0x63}
+	default:
+		return nil, errors.New("Device not supported!")
+	}
+	
+	b := make([]byte, size)
+	b[0] = header[0]
+	b[1] = header[1]
+	return b, nil
+}
+
+func brightnessPacket(device string) ([]byte, error) {
+	var size int
+	var header []byte
+
+	switch device {
+	case "Streamdeck XL", "Streamdeck (original v2)":
+		size = 32
+		header = []byte{0x03, 0x08}
+	case "Streamdeck Mini":
+		size = 17
+		header = []byte{0x05, 0x55, 0xaa, 0xd1, 0x01}
+	default:
+		return nil, errors.New("Device is not supported!")
+	}
+
+	b := make([]byte, size)
+	b[0] = header[0]
+	b[1] = header[1]
+	if device == "Streamdeck Mini" {
+		b[2] = header[2]
+		b[3] = header[3]
+		b[4] = header[4]
+	}
+	return b, nil
+}
+

--- a/devices/xl.go
+++ b/devices/xl.go
@@ -42,13 +42,25 @@ func init() {
 	xlButtonWidth = 96
 	xlButtonHeight = 96
 	xlImageReportPayloadLength = 1024
+	// Get reset packet from device name
+	reset, err := resetPacket(xlName)
+	if err != nil {
+		panic(err)
+	}
+	// Get brightness packet from device name
+	brightness, err := brightnessPacket(xlName)
+	if err != nil {
+		panic(err)
+	}
 	streamdeck.RegisterDevicetype(
 		xlName, // Name
 		image.Point{X: int(xlButtonWidth), Y: int(xlButtonHeight)}, // Width/height of a button
 		0x6c,                       // USB productID
-		[]byte{'\x03', '\x02'},     // Reset packet
+		reset,                      // Reset packet
 		32,                         // Number of buttons
-		[]byte{'\x03', '\x08'},     // Set brightness packet preamble
+		4,                          // Number of rows
+		8,                          // Number of cols
+		brightness,                 // Set brightness packet preamble
 		4,                          // Button read offset
 		"JPEG",                     // Image format
 		xlImageReportPayloadLength, // Amount of image payload allowed per USB packet


### PR DESCRIPTION
* Each device now also reports the number of rows and colums for each
  button. This could be used by GUI applications to easily display the
  layout.
* New devices.go file containing functions shared by each device's go
  file.
* Dynamically determine the Reset and Brightness packets

Fixes:
* Ensure the Mini's brightness packet contains all the header bytes