### PR TITLE
Fix a problem with packet size for brightness, and add an example

### DIFF
--- a/devices/shared.go
+++ b/devices/shared.go
@@ -18,7 +18,7 @@ func resetPacket32() []byte {
 
 // brightnessPacket17 gives the brightness packet for devices which need it to be 17 bytes long
 func brightnessPacket17() []byte {
-	pkt := make([]byte, 17)
+	pkt := make([]byte, 5)
 	pkt[0] = 0x05
 	pkt[1] = 0x55
 	pkt[2] = 0xaa
@@ -29,7 +29,7 @@ func brightnessPacket17() []byte {
 
 // brightnessPacket32 gives the brightness packet for devices which need it to be 32 bytes long
 func brightnessPacket32() []byte {
-	pkt := make([]byte, 32)
+	pkt := make([]byte, 2)
 	pkt[0] = 0x03
 	pkt[1] = 0x08
 	return pkt

--- a/examples/brightness/brightness.go
+++ b/examples/brightness/brightness.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"time"
+
+	streamdeck "github.com/magicmonkey/go-streamdeck"
+	"github.com/magicmonkey/go-streamdeck/buttons"
+	_ "github.com/magicmonkey/go-streamdeck/devices"
+)
+
+func main() {
+	// initialise the device
+	sd, err := streamdeck.New()
+	if err != nil {
+		panic(err)
+	}
+
+	sd.SetBrightness(40)
+
+	// create buttons
+	btn1 := buttons.NewTextButton("Brightness")
+	sd.AddButton(1, btn1)
+	btn2 := buttons.NewTextButton("40")
+	sd.AddButton(2, btn2)
+
+	// wait for one second
+	time.Sleep(1 * time.Second)
+
+	// set brightness
+	sd.SetBrightness(100)
+	btn2.SetText("100")
+
+	// program exits
+}


### PR DESCRIPTION
The brightness feature didn't work for the XL streamdecks, this fixes the packet size and adds an example so you can see it in action.

Inspired by and replaces #36 