### PR TITLE
Fix vertical centering

### DIFF
--- a/text.go
+++ b/text.go
@@ -45,7 +45,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	c.SetClip(dstImg.Bounds())
 
 	x := int((btnSize - width) / 2) // Horizontally centre text
-	y := int(50 + (size / 3))  // Fudged vertical centre, erm, very "heuristic"
+	y := int((float64(btnSize) / 2) + (size / 3)) // Fudged vertical centre, erm, very "heuristic"
 
 	pt := freetype.Pt(x, y)
 	c.DrawString(text, pt)


### PR DESCRIPTION
This makes text center vertically

I am not entirely sure if this is wanted / intended, but I am adding some simple text to buttons on a streamdeck mini and it looks really weird without this change... Let me know your thoughs