### PR TITLE
Add stream deck mk.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", MODE:="666"
 ```
 
 ## Usage

--- a/devices/origmk2.go
+++ b/devices/origmk2.go
@@ -1,0 +1,59 @@
+package devices
+
+import (
+	"image"
+
+	streamdeck "github.com/magicmonkey/go-streamdeck"
+)
+
+var (
+	omk2Name                     string
+	omk2ButtonWidth              uint
+	omk2ButtonHeight             uint
+	omk2ImageReportPayloadLength uint
+)
+
+// GetImageHeaderOv2 returns the USB comms header for a button image for the XL
+func GetImageHeaderOMK2(bytesRemaining uint, btnIndex uint, pageNumber uint) []byte {
+	thisLength := uint(0)
+	if ov2ImageReportPayloadLength < bytesRemaining {
+		thisLength = ov2ImageReportPayloadLength
+	} else {
+		thisLength = bytesRemaining
+	}
+	header := []byte{'\x02', '\x07', byte(btnIndex)}
+	if thisLength == bytesRemaining {
+		header = append(header, '\x01')
+	} else {
+		header = append(header, '\x00')
+	}
+
+	header = append(header, byte(thisLength&0xff))
+	header = append(header, byte(thisLength>>8))
+
+	header = append(header, byte(pageNumber&0xff))
+	header = append(header, byte(pageNumber>>8))
+
+	return header
+}
+
+func init() {
+	omk2Name = "Stream Deck MK.2"
+	omk2ButtonWidth = 72
+	omk2ButtonHeight = 72
+	omk2ImageReportPayloadLength = 1024
+	streamdeck.RegisterDevicetype(
+		omk2Name, // Name
+		image.Point{X: int(omk2ButtonWidth), Y: int(omk2ButtonHeight)}, // Width/height of a button
+		0x80,                         // USB productID
+		resetPacket32(),              // Reset packet
+		15,                           // Number of buttons
+		3,                            // Number of rows
+		5,                            // Number of columns
+		brightnessPacket32(),         // Set brightness packet preamble
+		4,                            // Button read offset
+		"JPEG",                       // Image format
+		omk2ImageReportPayloadLength, // Amount of image payload allowed per USB packet
+		GetImageHeaderOMK2,           // Function to get the comms image header
+	)
+}

--- a/image.go
+++ b/image.go
@@ -25,19 +25,19 @@ func resizeAndRotate(img image.Image, width, height int, devname string) image.I
 
 func deviceSpecifics(devName string, width, height int) (*gift.GIFT, error) {
 	switch devName {
-		case "Streamdeck XL", "Streamdeck (original v2)":
-			return gift.New(
-				gift.Resize(width, height, gift.LanczosResampling),
-				gift.Rotate180(),
-			), nil
-		case "Streamdeck Mini":
-			return gift.New(
-				gift.Resize(width, height, gift.LanczosResampling),
-				gift.Rotate90(),
-				gift.FlipVertical(),
-			), nil
-		default:
-			return nil, errors.New(fmt.Sprintf("Unsupported Device: %s", devName))
+	case "Streamdeck XL", "Streamdeck (original v2)", "Stream Deck MK.2":
+		return gift.New(
+			gift.Resize(width, height, gift.LanczosResampling),
+			gift.Rotate180(),
+		), nil
+	case "Streamdeck Mini":
+		return gift.New(
+			gift.Resize(width, height, gift.LanczosResampling),
+			gift.Rotate90(),
+			gift.FlipVertical(),
+		), nil
+	default:
+		return nil, errors.New(fmt.Sprintf("Unsupported Device: %s", devName))
 	}
 }
 
@@ -56,7 +56,7 @@ func getImageForButton(img image.Image, btnFormat string) ([]byte, error) {
 
 func getSolidColourImage(colour color.Color, btnSize int) *image.RGBA {
 	img := image.NewRGBA(image.Rect(0, 0, btnSize, btnSize))
-	//colour := color.RGBA{red, green, blue, 0}
+	// colour := color.RGBA{red, green, blue, 0}
 	draw.Draw(img, img.Bounds(), image.NewUniform(colour), image.Point{0, 0}, draw.Src)
 	return img
 }


### PR DESCRIPTION
Adds the newer stream deck mk.2 to the known devices and add the new product id to udev rules.

Works with these settings on my system.