### PR TITLE
Add mutexes to adding buttons and button image writes

### DIFF
--- a/comms.go
+++ b/comms.go
@@ -139,12 +139,12 @@ func (d *Device) SetBrightness(pct int) error {
 }
 
 // GetButtonImageSize returns the size of the images to uploaded to the buttons
-func (d* Device) GetButtonImageSize() image.Point {
+func (d *Device) GetButtonImageSize() image.Point {
 	return d.deviceType.imageSize
 }
 
 // GetNumButtonsOnDevice returns the number of button this device has
-func (d* Device) GetNumButtonsOnDevice() uint {
+func (d *Device) GetNumButtonsOnDevice() uint {
 	return d.deviceType.numberOfButtons
 }
 

--- a/streamdeck.go
+++ b/streamdeck.go
@@ -1,6 +1,9 @@
 package streamdeck
 
-import "image"
+import (
+	"image"
+	"sync"
+)
 
 // ButtonDisplay is the interface to satisfy for displaying on a button
 type ButtonDisplay interface {
@@ -31,6 +34,7 @@ type StreamDeck struct {
 	dev        *Device
 	buttons    map[int]Button
 	decorators map[int]ButtonDecorator
+	mu         sync.Mutex
 }
 
 // New will return a new instance of a `StreamDeck`, and is the main entry point for the higher-level interface.  It will return an error if there is no StreamDeck plugged in.
@@ -56,6 +60,8 @@ func (sd *StreamDeck) GetName() string {
 func (sd *StreamDeck) AddButton(btnIndex int, b Button) {
 	b.RegisterUpdateHandler(sd.ButtonUpdateHandler)
 	b.SetButtonIndex(btnIndex)
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
 	sd.buttons[btnIndex] = b
 	sd.updateButton(b)
 }


### PR DESCRIPTION
When running `AddButton` in a go-routine, I received the following errors:

```
fatal error: concurrent map writes

goroutine 13 [running]:
github.com/magicmonkey/go-streamdeck.(*StreamDeck).AddButton(0xc000122a68, 0xe?, {0x8b68e0, 0xc0000aa050})
	/home/derick/dev/go/src/github.com/magicmonkey/go-streamdeck/streamdeck.go:59 +0xa7
github.com/derickr/streamdeck-goui/addons.(*Clock).Init.func1(0x6)
	/home/derick/dev/go/src/github.com/derickr/streamdeck-goui/addons/clock.go:70 +0x7b7
created by github.com/derickr/streamdeck-goui/addons.(*Clock).Init
	/home/derick/dev/go/src/github.com/derickr/streamdeck-goui/addons/clock.go:48 +0x30
```

It turned out that the method did not use a mutex for this.

Similarly, I frequently got corrupt images, and the addition of the mutex to the function that writes these images to the Stream Deck fixes that.