### PR TITLE
Fixed font-size estimation

### DIFF
--- a/buttons/text.go
+++ b/buttons/text.go
@@ -104,7 +104,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	width := 0
 	for size = 1; size < 60; size++ {
 		width = getTextWidth(text, size)
-		if width > 90 {
+		if width > btnSize {
 			size = size - 1
 			break
 		}
@@ -123,7 +123,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	c.SetClip(dstImg.Bounds())
 
 	x := int((btnSize - width) / 2) // Horizontally centre text
-	y := int(50 + (size / 3))  // Fudged vertical centre, erm, very "heuristic"
+	y := int(btnSize / 2) + int(size / 3)  // Fudged vertical centre, erm, very "heuristic"
 
 	pt := freetype.Pt(x, y)
 	c.DrawString(text, pt)

--- a/buttons/text.go
+++ b/buttons/text.go
@@ -20,11 +20,12 @@ type TextButton struct {
 	updateHandler    func(streamdeck.Button)
 	btnIndex         int
 	actionHandler    streamdeck.ButtonActionHandler
+	margin           int
 }
 
 // GetImageForButton is the interface implemention to get the button's image as an image.Image
 func (btn *TextButton) GetImageForButton(btnSize int) image.Image {
-	img := getImageWithText(btn.label, btn.textColour, btn.backgroundColour, btnSize)
+	img := getImageWithText(btn.label, btn.textColour, btn.backgroundColour, btnSize, btn.margin)
 	return img
 }
 
@@ -80,7 +81,15 @@ func (btn *TextButton) Pressed() {
 // background.  The text will be set on a single line, and auto-sized to fill the button as best
 // as possible.
 func NewTextButton(label string) *TextButton {
-	btn := NewTextButtonWithColours(label, color.White, color.Black)
+	btn := NewTextButtonWithColoursAndMargin(label, color.White, color.Black, 6)
+	return btn
+}
+
+// NewTextButtonWithMargin creates a new TextButton with the specified text on it, in white on a
+// black background.  The text will be set on a single line, and auto-sized to fill the button as
+// best as possible, taking into account the margin on each side.
+func NewTextButtonWithMargin(label string, margin int) *TextButton {
+	btn := NewTextButtonWithColoursAndMargin(label, color.White, color.Black, margin)
 	return btn
 }
 
@@ -88,11 +97,20 @@ func NewTextButton(label string) *TextButton {
 // text and background colours.  The text will be set on a single line, and auto-sized to fill the
 // button as best as possible.
 func NewTextButtonWithColours(label string, textColour color.Color, backgroundColour color.Color) *TextButton {
-	btn := &TextButton{label: label, textColour: textColour, backgroundColour: backgroundColour}
+	btn := NewTextButtonWithColoursAndMargin(label, textColour, backgroundColour, 6)
 	return btn
 }
 
-func getImageWithText(text string, textColour color.Color, backgroundColour color.Color, btnSize int) image.Image {
+// NewTextButtonWithColoursAndMargin creates a new TextButton with the specified text on it, in the
+// specified text and background colours.  The text will be set on a single line, and auto-sized to
+// fill the button as best as possible, taking into account the margin on each side.
+func NewTextButtonWithColoursAndMargin(label string, textColour color.Color, backgroundColour color.Color, margin int) *TextButton {
+	btn := &TextButton{label: label, textColour: textColour, backgroundColour: backgroundColour, margin: margin}
+	return btn
+}
+
+
+func getImageWithText(text string, textColour color.Color, backgroundColour color.Color, btnSize int, margin int) image.Image {
 
 	size := float64(18)
 
@@ -104,7 +122,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	width := 0
 	for size = 1; size < 60; size++ {
 		width = getTextWidth(text, size)
-		if width >= btnSize {
+		if width >= btnSize - (margin * 2) {
 			size = size - 1
 			break
 		}

--- a/buttons/text.go
+++ b/buttons/text.go
@@ -104,7 +104,7 @@ func getImageWithText(text string, textColour color.Color, backgroundColour colo
 	width := 0
 	for size = 1; size < 60; size++ {
 		width = getTextWidth(text, size)
-		if width > btnSize {
+		if width >= btnSize {
 			size = size - 1
 			break
 		}


### PR DESCRIPTION
In one of the commits that added support for the mini, and further commits, a new 'btnSize' parameter was introduced.

This however was not reflected in the algorithm that determines the size.

Without this fix, the text was always too wide (90px is more than the 72px my stream deck has), and also no longer virtually centred.

This commit should address both these issues.

I've only tested this with the v2.